### PR TITLE
Build for Devuan Chimaera

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CFLAGS += -Wno-error=deprecated-declarations
+
 all: libsystemuiplugin_power_key_menu.so
 
 clean:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+osso-systemui-powerkeymenu (0.4.2) unstable; urgency=medium
+  * Changed cflags for compatibility with GCC 10+
+
+ -- Blagovest Petrov <blagovest@petrovs.info> Sat, 26 Nov 2022 2:26:57 +0200
+
 osso-systemui-powerkeymenu (0.4.1) unstable; urgency=medium
 
   * Do not override log ident set by systemui when not standalone


### PR DESCRIPTION
Added cflag for ignoring GTK deprecation warnings. It was failing with those errors:

```
.....
In file included from /usr/include/gtk-2.0/gtk/gtktoolitem.h:31,
                 from /usr/include/gtk-2.0/gtk/gtktoolbutton.h:30,
                 from /usr/include/gtk-2.0/gtk/gtkmenutoolbutton.h:30,
                 from /usr/include/gtk-2.0/gtk/gtk.h:126,
                 from osso-systemui-powerkeymenu.c:37:
/usr/include/gtk-2.0/gtk/gtktooltips.h:73:3: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   73 |   GTimeVal last_popdown;
      |   ^~~~~~~~
....
```